### PR TITLE
Fix podspec

### DIFF
--- a/SendBirdSDK.podspec
+++ b/SendBirdSDK.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.authors      = {
     'Jed Gyeong' => 'jed.gyeong@sendbird.com',
     'Celine Moon' => 'celine.moon@sendbird.com',
-    'Ernest Hong' => 'ernest.hong@sendbird.com'
+    'Ernest Hong' => 'ernest.hong@sendbird.com',
     'Damon Park' => 'damon.park@sendbird.com'
   }
   s.source       = { :git => 'https://github.com/sendbird/sendbird-ios-framework.git', :tag => "v3.1.49" }

--- a/generate_podspec.sh
+++ b/generate_podspec.sh
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.authors      = {
     'Jed Gyeong' => 'jed.gyeong@sendbird.com',
     'Celine Moon' => 'celine.moon@sendbird.com',
-    'Ernest Hong' => 'ernest.hong@sendbird.com'
+    'Ernest Hong' => 'ernest.hong@sendbird.com',
     'Damon Park' => 'damon.park@sendbird.com'
   }
   s.source       = { :git => 'https://github.com/sendbird/sendbird-ios-framework.git', :tag => \"v$VERSION\" }


### PR DESCRIPTION
The error occurred when executing `pod turnk push`

```
$ pod trunk push

[!] Found podspec `SendBirdSDK.podspec`
Updating spec repo `trunk`
Validating podspec
[!] Unable to interpret the specified path `SendBirdSDK.podspec` as a podspec (Pod::DSLError).
```

The error occurred because there were elements that did not fit the podspec format.

```
$ pod spec lint --verbose

  CDN: trunk Relative path: CocoaPods-version.yml exists! Returning local because checking is only performed in repo update
 -> SendBirdSDK.podspec
    - ERROR | spec: The specification defined in `SendBirdSDK.podspec` could not be loaded.


[!] Invalid `SendBirdSDK.podspec` file: syntax error, unexpected string literal, expecting '}'
    'Damon Park' => 'damon.park@se...
    ^
sendbird-ios-framework/SendBirdSDK.podspec:14: syntax error, unexpected '}', expecting `end'
sendbird-ios-framework/SendBirdSDK.podspec:22: syntax error, unexpected `end', expecting end-of-input.

 #  from ~/Dev/sendbird-ios-framework/SendBirdSDK.podspec:13
 #  -------------------------------------------
 #      'Ernest Hong' => 'ernest.hong@sendbird.com'
 >      'Damon Park' => 'damon.park@sendbird.com'
 #    }
 #  -------------------------------------------


Analyzed 1 podspec.

[!] The spec did not pass validation, due to 1 error.

~/.gem/ruby/3.1.0/gems/cocoapods-1.12.1/lib/cocoapods/command/spec/lint.rb:107:in `run'
~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/claide-1.1.0/lib/claide/command.rb:334:in `run'
~/.gem/ruby/3.1.0/gems/cocoapods-1.12.1/lib/cocoapods/command.rb:52:in `run'
~/.gem/ruby/3.1.0/gems/cocoapods-1.12.1/bin/pod:55:in `<top (required)>'
~/.gem/ruby/3.1.0/bin/pod:25:in `load'
~/.gem/ruby/3.1.0/bin/pod:25:in `<main>'
```